### PR TITLE
Removed Image ghosting using css select and drag properties

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -267,3 +267,13 @@ hr {
   --background: var(--black);
   --textColor: var(--lightGrey);
 }
+
+/* Remove image ghosting */
+    
+img{
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+}


### PR DESCRIPTION
We have a lot of image elements on the website and removing image ghosting just added a little more touch to the UX just like the custom selection color 🌮 
There was also a method of setting the draggable attribute to false on each separate image so instead, I used CSS to override the select behavior

https://user-images.githubusercontent.com/19896788/102880487-64ea4500-4471-11eb-86cd-1111c4c68581.mp4

